### PR TITLE
python3.7, dependency add, subnet read fix

### DIFF
--- a/bin/traixroute
+++ b/bin/traixroute
@@ -24,7 +24,7 @@ path="$(cd "$(dirname "$0")"/.. ; pwd)"
 
 export PYTHONPATH="$path"/lib
 
-for INTERPRETER in "$INTERPRETER" pypy3 python3 python3.3 python3.4 python3.5; do
+for INTERPRETER in "$INTERPRETER" pypy3 python3 python3.3 python3.4 python3.5 python3.7; do
         INTERPRETER="$(command -v "$INTERPRETER")" && break
 done
 

--- a/lib/traixroute/handler/handle_pch.py
+++ b/lib/traixroute/handler/handle_pch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2016 Institute of Computer Science of the Foundation for Research and Technology - Hellas (FORTH)
 # Authors: Michalis Bamiedakis, Dimitris Mavrommatis and George Nomikos

--- a/lib/traixroute/handler/handle_pch.py
+++ b/lib/traixroute/handler/handle_pch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Institute of Computer Science of the Foundation for Research and Technology - Hellas (FORTH)
 # Authors: Michalis Bamiedakis, Dimitris Mavrommatis and George Nomikos
@@ -138,19 +138,19 @@ class pch_handle():
         IXP_cc = {}
         subnets = {}
         Subnet_names = SubnetTree.SubnetTree()
-        
+
         # Skip the first line of the file.
         next(doc)
         for line in doc:
             temp_string = line.split(',')
             if len(temp_string) > 5:
                 mykey = temp_string[0]
-                myip = handled_string.extract_ip(temp_string[6], 'Subnet')
-                
+                myip = handled_string.extract_ip(temp_string[5], 'Subnet')
+
                 for ips in myip:
                     # Clean misspelled Subnets.
                     ips = handled_string.clean_ip(ips, 'Subnet')
-                    
+
                     if ips != '' and handled_string.string_comparison(temp_string[2], 'Active'):
                         if handled_string.is_valid_ip_address(ips, 'Subnet', 'PCH') and ips not in subnets:
                             if mykey in long_mem.keys():
@@ -188,10 +188,10 @@ class pch_handle():
                                     handled_string.assign_names(
                                         IXP[0], short_name, IXP[1], long_name)
                             subnets[ips] = assigned_tuple
-                                                    
+
                         if ips in subnets:
                             Subnet_names[ips] = subnets[ips]
-        
+
         doc.close()
         return (subnets, IXP_cc, Subnet_names)
 
@@ -206,17 +206,17 @@ class pch_handle():
             a) ixpip2long: A dictionary with {keyid}=[IXP long name].
             b) IXP_region: A dictionary with {keyid}=[IXP country, IXP city].
         '''
-        
+
         handle_string = string_handler.string_handler()
         doc = self.file_opener(self.filename_excha, 2)
         ixpip2long = {}
         IXP_region = {}
-        
+
         # Skip the first line of the file.
         next(doc)
         for line in doc:
             temp_string = [item.strip() for item in line.split(', ')]
-            
+
             if len(temp_string) > 6:
                 if handle_string.string_comparison(temp_string[6], 'Active'):
                     # IXP long name
@@ -225,13 +225,13 @@ class pch_handle():
                     country = handle_string.format_country_city(temp_string[2])
                     # City name
                     city = handle_string.format_country_city(temp_string[3])
-                    
+
                     try:
                         IXP_region[temp_string[0]] = country2cc[country], city
                     except KeyError:
                         print('Warning, update your CCs for:', country)
                         IXP_region[temp_string[0]] = country, city
-        
+
         doc.close()
         return (ixpip2long, IXP_region)
 

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -25,10 +25,10 @@ cur_dir=$(dirname $0)
 
 additional(){
 
-    sudo pip install --upgrade -r $cur_dir/requirements.txt
+    sudo pip3 install --upgrade -r $cur_dir/requirements.txt
 
     if ! hash scamper 2>/dev/null; then
-        sudo python $cur_dir/../lib/traixroute/downloader/install_scamper.py
+        sudo python3 $cur_dir/../lib/traixroute/downloader/install_scamper.py
     fi
 }
 
@@ -44,14 +44,14 @@ if [ $OS = 'Darwin' ]; then
         echo 'Exit.'
     elif [ $installed -eq 0 ]; then 
         echo 'Xcode Command Line Tools are installed.'
-        python -V &>/dev/null;
+        python3 -V &>/dev/null;
         if [ $? -ne 0 ]; then
             echo 'Python 3 is not installed.'
             installer -pkg $cur_dir/python-3.4.4-macosx10.6.pkg -target /
             echo 'Installing dependencies for OS X.'
             additional
         else
-            python -c "import sys; exit(float(sys.version[0:3])>=3.4)"
+            python3 -c "import sys; exit(float(sys.version[0:3])>=3.4)"
             if [ $? -eq 1 ]; then
                 echo 'Python version is >= 3.4.'
                 echo 'Installing dependencies for OS X.'

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -25,11 +25,10 @@ cur_dir=$(dirname $0)
 
 additional(){
 
-    sudo pip3 install --upgrade pip
-    sudo pip3 install --upgrade -r $cur_dir/requirements.txt
-    
+    sudo pip install --upgrade -r $cur_dir/requirements.txt
+
     if ! hash scamper 2>/dev/null; then
-        sudo python3 $cur_dir/../lib/traixroute/downloader/install_scamper.py
+        sudo python $cur_dir/../lib/traixroute/downloader/install_scamper.py
     fi
 }
 
@@ -45,14 +44,14 @@ if [ $OS = 'Darwin' ]; then
         echo 'Exit.'
     elif [ $installed -eq 0 ]; then 
         echo 'Xcode Command Line Tools are installed.'
-        python3 -V &>/dev/null;
+        python -V &>/dev/null;
         if [ $? -ne 0 ]; then
             echo 'Python 3 is not installed.'
             installer -pkg $cur_dir/python-3.4.4-macosx10.6.pkg -target /
             echo 'Installing dependencies for OS X.'
             additional
         else
-            python3 -c "import sys; exit(float(sys.version[0:3])>=3.4)"
+            python -c "import sys; exit(float(sys.version[0:3])>=3.4)"
             if [ $? -eq 1 ]; then
                 echo 'Python version is >= 3.4.'
                 echo 'Installing dependencies for OS X.'
@@ -66,7 +65,7 @@ if [ $OS = 'Darwin' ]; then
 elif [ $OS = 'Linux' ]; then
     echo 'Installing dependencies for Linux.'
     sudo apt-get update
-    sudo apt-get install g++ gcc python3 python3-setuptools python3-dev traceroute python3-pip libssl-dev libffi-dev -y
+    sudo apt-get install g++ gcc traceroute libssl-dev libffi-dev -y
     additional
 
 # Not supported OS.

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -16,3 +16,4 @@ ujson==1.35
 websocket-client==0.37.0
 fuzzywuzzy[speedup]==0.16.0
 netaddr==0.7.19
+setuptools==40.6.3


### PR DESCRIPTION
1. stop breaking built python; manually setup with `update-alternatives`
2. add support for python3.7
3. require `setuptools`
4. fix `index out of range` when reading subnet